### PR TITLE
Make corestore Clone, use interior mutability.

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -18,7 +18,7 @@ const STORAGE_DIR: &str = ".hyperspace-rs";
 /// Shared application state.
 #[derive(Clone)]
 pub struct State {
-    corestore: Arc<Mutex<Corestore>>,
+    corestore: Corestore,
     replicator: Replicator,
 }
 
@@ -45,7 +45,6 @@ pub async fn listen(opts: Opts) -> anyhow::Result<()> {
 
     // Open a corestore and wrap in Arc<Mutex>
     let corestore = Corestore::open(storage).await?;
-    let corestore = Arc::new(Mutex::new(corestore));
 
     // Create a replicator
     let replicator = Replicator::new();

--- a/server/src/rpc/session.rs
+++ b/server/src/rpc/session.rs
@@ -14,7 +14,7 @@ use crate::State;
 #[derive(Clone)]
 pub struct Session {
     client: Client,
-    corestore: Arc<Mutex<Corestore>>,
+    corestore: Corestore,
     cores: Arc<Mutex<HashMap<u32, Arc<Mutex<Feed>>>>>,
 }
 
@@ -77,19 +77,9 @@ impl server::Corestore for Session {
     async fn open(&mut self, req: OpenRequest) -> io::Result<OpenResponse> {
         trace!("req: {:?}", req);
         let feed = if let Some(name) = req.name {
-            self.corestore
-                .lock()
-                .await
-                .get_by_name(name)
-                .await
-                .map_err(map_err)?
+            self.corestore.get_by_name(name).await.map_err(map_err)?
         } else if let Some(key) = req.key {
-            self.corestore
-                .lock()
-                .await
-                .get_by_key(key)
-                .await
-                .map_err(map_err)?
+            self.corestore.get_by_key(key).await.map_err(map_err)?
         } else {
             return Err(Error::new(ErrorKind::Other, "Invalid parameters"));
         };


### PR DESCRIPTION
- Add InnerCorestore that's inside an RwLock in the Corestore
- Public async methods lock the inner corestore first
- Remove external Arc<Mutex<Corestore>> wrappers