### PR TITLE
Updates to get the example in the README.md working

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ members = ["client","server", "common", "corestore", "replicator"]
 
 [patch.crates-io]
 hypercore = { git = "https://github.com/Frando/datrs-hypercore", branch = "hyperspace" }
-hypercore-protocol = { git = "https://github.com/Frando/hypercore-protocol-rs", branch = "reduce-async" }
 libutp-sys = { git = "https://github.com/cowlicks/libutp-sys.git", branch = "fix-build-failure", optional = true }
 # hrpc = { path = "../hrpc" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["client","server", "common", "corestore", "replicator", "examples/*"]
+members = ["client","server", "common", "corestore", "replicator"]
 
 [patch.crates-io]
 hypercore = { git = "https://github.com/Frando/datrs-hypercore", branch = "hyperspace" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = ["client","server", "common", "corestore", "replicator"]
 [patch.crates-io]
 hypercore = { git = "https://github.com/Frando/datrs-hypercore", branch = "hyperspace" }
 hypercore-protocol = { git = "https://github.com/Frando/hypercore-protocol-rs", branch = "reduce-async" }
+libutp-sys = { git = "https://github.com/cowlicks/libutp-sys.git", branch = "fix-build-failure", optional = true }
 # hrpc = { path = "../hrpc" }
 
 # Needed until https://github.com/danburkert/prost/pull/317 is merged.

--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ This example starts two `hyperspace-server` instances and runs a hyperswarm DHT 
 cargo run --bin hyperspace-server -- --dht -a 127.0.0.1:3401
 
 # 2. Start server 1
-cargo run --bin hyperspace-server -- -s /tmp/hs1 -h hs1 -b 127.0.0.1:3401
+cargo run --bin hyperspace-server -- -s /tmp/hs1 --host hs1 -b 127.0.0.1:3401
 
 # 3. Start server 2
-cargo run --bin hyperspace-server -- -s /tmp/hs2 -h hs2 -b 127.0.0.1:3401
+cargo run --bin hyperspace-server -- -s /tmp/hs2 --host hs2 -b 127.0.0.1:3401
 
 # 4. Write to a feed on server 1
-cargo run --bin hyperspace-client -- -h hs1 -n afeed write
+cargo run --bin hyperspace-client -- --host hs1 -n afeed write
 # the feed's key will be printed
 # (type something and press enter, it will be appended to the feed)
 
 # 5. Read from the feed from server 2
-cargo run --bin hyperspace-client -- -h hs2 -k KEY_FROM_ABOVE read
+cargo run --bin hyperspace-client -- --host hs2 -k KEY_FROM_ABOVE read
 ```
 
 ### Contributing

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,4 +23,4 @@ prost = "0.6.1"
 chashmap = "2.2.2"
 parking_lot = { version = "0.11.0", features = ["send_guard"] }
 hex = "0.4.2"
-clap = "3.0.0-beta.1"
+clap = { version = "4.5.4", features = ["derive"] }

--- a/client/src/bin.rs
+++ b/client/src/bin.rs
@@ -36,7 +36,7 @@ pub struct Opts {
     pub name: Option<String>,
 
     /// Override socket name to connect to
-    #[arg(short, long)]
+    #[arg(long)]
     pub host: Option<String>,
 
     #[command(subcommand)]

--- a/client/src/bin.rs
+++ b/client/src/bin.rs
@@ -10,7 +10,7 @@ use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task;
 use async_trait::async_trait;
-use clap::Clap;
+use clap::{Parser, Subcommand};
 use env_logger::Env;
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::stream::{StreamExt, TryStreamExt};
@@ -25,24 +25,25 @@ use hyperspace_client::codegen;
 use hyperspace_client::{RemoteCorestore, RemoteHypercore};
 use hyperspace_common::socket_path;
 
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
 pub struct Opts {
     /// Hypercore key
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub key: Option<String>,
     /// Hypercore name
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub name: Option<String>,
 
     /// Override socket name to connect to
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub host: Option<String>,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: Command,
 }
 
-#[derive(Clap, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum Command {
     /// Read from a Hypercore
     Read,

--- a/replicator/Cargo.toml
+++ b/replicator/Cargo.toml
@@ -12,7 +12,8 @@ anyhow = "1.0.31"
 async-std = { version = "1.9", features = ["unstable"] }
 futures = "0.3.5"
 hypercore = { git = "https://github.com/Frando/datrs-hypercore", branch = "hyperspace" }
-hypercore-protocol = "0.3.0"
+hypercore-protocol = { git = "https://github.com/cowlicks/hypercore-protocol-rs.git", branch = "fix-deps-v3.1" }
+
 # hypercore-protocol = { git = "https://github.com/Frando/hypercore-protocol-rs", branch = "reduce-async" }
 sparse-bitfield = "0.11.0"
 hex = "0.4.2"

--- a/replicator/src/peer.rs
+++ b/replicator/src/peer.rs
@@ -73,6 +73,7 @@ pub struct Peer {
 
 #[derive(Debug, Default, Clone)]
 pub struct Stats {
+    #[allow(dead_code)]
     id: RemotePublicKey,
     downloaded_blocks: u64,
     downloaded_bytes: u64,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,6 +26,6 @@ async-trait = "0.1.36"
 anyhow = "1.0.31"
 prost = "0.6.1"
 hex = "0.4"
-clap = "3.0.0-beta.1"
+clap = { version = "4.5.4", features = ["derive"] }
 dirs = "3.0.1"
 async-signals = "0.3.1"

--- a/server/src/bin.rs
+++ b/server/src/bin.rs
@@ -1,5 +1,5 @@
 use async_std::task;
-use clap::Clap;
+use clap::Parser;
 use hyperspace_server::{listen, run_bootstrap_node, Opts};
 
 fn main() -> anyhow::Result<()> {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -17,6 +17,7 @@ const STORAGE_DIR: &str = ".hyperspace-rs";
 #[derive(Clone)]
 pub struct State {
     corestore: Corestore,
+    #[allow(dead_code)]
     replicator: Replicator,
 }
 

--- a/server/src/network.rs
+++ b/server/src/network.rs
@@ -14,7 +14,7 @@ pub async fn run(mut replicator: Replicator, opts: Opts) -> io::Result<()> {
     enum Event {
         Replicator(ReplicatorEvent),
         Swarm(io::Result<HyperswarmStream>),
-    };
+    }
 
     let mut events = replicator_events
         .map(Event::Replicator)

--- a/server/src/network.rs
+++ b/server/src/network.rs
@@ -42,7 +42,7 @@ pub async fn run(mut replicator: Replicator, opts: Opts) -> io::Result<()> {
 async fn swarm_config_from_opts(opts: Opts) -> io::Result<Config> {
     let config = Config::default();
     let config = if opts.bootstrap.len() > 0 {
-        config.set_bootstrap_nodes(opts.bootstrap[..].to_vec())
+        config.set_bootstrap_nodes(&opts.bootstrap[..].to_vec())
     } else {
         config
     };

--- a/server/src/options.rs
+++ b/server/src/options.rs
@@ -16,7 +16,7 @@ pub struct Opts {
     ///
     /// The actual socket will be created at tmpdir/[host].sock
     /// Defaults to "hyperspace".
-    #[clap(short, long)]
+    #[clap(long)]
     pub host: Option<String>,
 
     /// Address to which Hyperswarm binds

--- a/server/src/options.rs
+++ b/server/src/options.rs
@@ -34,11 +34,6 @@ pub struct Opts {
     /// Run a local bootstrapping dht node
     #[clap(long)]
     pub dht: bool,
-
-    /// A level of verbosity, and can be used multiple times
-    //#[clap(short, long, parse(from_occurrences))] // FIXME maybe
-    #[clap(short, long)]
-    pub verbose: i32,
 }
 
 impl Default for Opts {
@@ -50,7 +45,6 @@ impl Default for Opts {
             bootstrap: vec![],
             port: None,
             dht: false,
-            verbose: 0,
         }
     }
 }

--- a/server/src/options.rs
+++ b/server/src/options.rs
@@ -1,9 +1,10 @@
-use clap::Clap;
+use clap::Parser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
 /// Options for the storage daemon
-#[derive(Clap, Debug)]
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
 pub struct Opts {
     /// Set storage path
     ///
@@ -35,7 +36,8 @@ pub struct Opts {
     pub dht: bool,
 
     /// A level of verbosity, and can be used multiple times
-    #[clap(short, long, parse(from_occurrences))]
+    //#[clap(short, long, parse(from_occurrences))] // FIXME maybe
+    #[clap(short, long)]
     pub verbose: i32,
 }
 


### PR DESCRIPTION
These changes were needed to get the [example in the `README.md`](https://github.com/datrs/hyperspace-rs?tab=readme-ov-file#example) working, and to silence existing warnings. There was only one existing test, and it passes.

The only thing that may be controversial here are these two places where I've patched dependencies, and point to my own fork. This is intended to be a temporary solution. The practice is common within this repo. User @Frando own several of these branches, but he is a more well known community member :wink:.
* [this line](https://github.com/datrs/hyperspace-rs/compare/master...cowlicks:get-this-working?body=&expand=1#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R7) points to a branch that includes [this PR](https://github.com/johsunds/libutp-sys/pull/1) to `libutp-sys` which I made to fix a build failure in `bindgen`.
* [this line](https://github.com/datrs/hyperspace-rs/compare/master...cowlicks:get-this-working?body=&expand=1#diff-b94951e51b3f76f279ee075a75bf738d8fbe8027576f08a1b02c34dccc2039fdR15). Where we were using `hypercore-protocol-rs v3.1`  However building this version is now broken because of it's dependency on `snow v0.7.0-alpha5` which causes a build failure. The branch this now points to contains [this patch](https://github.com/cowlicks/hypercore-protocol-rs/commit/f24ceb332f8200a7ddd43b19665ce9bb5d3d3766) which bumps the snow version to one that works (`0.8`). I would like to merge this upstream but the `hypercore-protocol-rs` repository does not have a `3.1` tag or branch which I could make a PR against. A different fix could be bumping the `hypercore-protocol-rs` version itself. I'm looking into this.